### PR TITLE
Update w/ 2022 speakers

### DIFF
--- a/schedule.md
+++ b/schedule.md
@@ -3,14 +3,9 @@ layout: longview_default
 title: Schedule
 ---
 
-<h1 class="text-center my-5" id="top">Schedule</h1>
 
----
-layout: longview_default
-title: Schedule
----
 
-<h1 class="text-center my-5" id="top">Schedule</h1>
+<h1 class="text-center my-5" id="top">2022 Schedule</h1>
 
 <div class="card" id="Menon">
 	<div class="card-body past-talk">
@@ -92,6 +87,7 @@ title: Schedule
 	</div>
 </div>
 
+<h1 class="text-center my-5" id="top">Previous 2021 Events</h1>
 
 
 <div class="card" id="milligan">

--- a/schedule.md
+++ b/schedule.md
@@ -5,6 +5,237 @@ title: Schedule
 
 <h1 class="text-center my-5" id="top">Schedule</h1>
 
+---
+layout: longview_default
+title: Schedule
+---
+
+<h1 class="text-center my-5" id="top">Schedule</h1>
+
+<div class="card" id="Menon">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Thursday, 10 March 2022</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Decolonizing Knowledge Infrastructures: Open Access and Multilingual Scholarly Publishing</h5>
+		<p class="card-subtitle mb-2">This talk will examine the emerging areas of research in Digital Humanities in India by an examination of the term “Digital Humanities” and its uneven and uncertain trajectory in the Indian research ecosystem. As with other systems around the world, DH in India is complex and contextual and each of us involved in the disciplinary practice encounter resistance and skepticism.  Resistance to what is perceived as a deliberate distancing from the larger Humanities queries, scepticism about appropriating the rhetoric of STEM disciplines merely as a tool for greater legitimacy and validation. But of course DH is far more than a sum of its criticisms and scepticisms. I will address why it is imperative that the digital be harnessed, critiqued, deconstructed and dissected precisely so that the issues that Humanities scholars have been invested in continue to be at the centre of the development, deployment and dissemination of technology.</p>
+		<strong>Speaker</strong>: <a href="http://people.iiti.ac.in/~nmenon/index.html">Prof. Nirmala Menon</a> (IIT Indore)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 9:00 PST (17:00 GMT)</a><br/>
+    <strong>Registration</strong>: Interested participants may register <a href="https://stanford.zoom.us/webinar/register/WN_GvXS4WrzSHWAL7oecw46SQ">here</a><br/>
+		<strong>Chair</strong>: Agnieszka Backman<br/> 
+		<strong>Uppsala Respondent</strong>: TBD<br/>
+		<strong>Stanford Respondent</strong>: Andrew Nelson
+	</div>
+</div>
+<p></p>
+<div class="card" id="Parker">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Thursday, 7 April 2022</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Curating Enslaved Pasts of the Cape of Good Hope</h5>
+		<strong>Speaker</strong>: <a href="https://classics.stanford.edu/people/grant-parker">Prof. Grant Parker </a>(Stanford)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 9:00 PST (17:00 GMT)<br/>
+    <strong>Registration</strong>: Interested participants may register <a href="https://stanford.zoom.us/webinar/register/WN_V1wQuBbkTUaZQRwIJ00DHQ">here</a><br/>
+		<strong>Chair</strong>: Laura Stokes<br/> 
+		<strong>UCL Respondent</strong>: Meishu Ai<br/>
+		<strong>Stanford Respondent</strong>: Dr. Denise Lim
+	</div>
+</div>
+<p></p>
+<div class="card" id="Pålsson">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Thursday, 21 April 2022</h4>
+		<h5 class="card-subtitle mb-2 text-muted">SWECARCOL. Swedish Caribbean Colonialism 1784–1878: Research, Challenges and Opportunities for Caribbean Digital History</h5>
+		<p class="card-subtitle mb-2">The Swedish Caribbean Colonialism 1784–1878 project (SweCarCol) integrates, orders and opens up important dispersed archives for research by publishing them on the Internet in cooperation with Uppsala University Library.</p>
+		<strong>Speakers</strong>: <a href="https://katalog.uu.se/profile/?id=N19-1328">Dr. Ale Pålsson</a> and <a href="https://katalog.uu.se/profile/?id=N19-1307">Dr. Victor Wilson</a> (Uppsala)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 9:00 PST (17:00 GMT)<br/>
+    <strong>Registration</strong>: Interested participants may register <a href="https://stanford.zoom.us/webinar/register/WN_tkkkashxRuKdqnZ8jljdQA">here</a><br/>
+		<strong>Chair</strong>: Clelia La Monica<br/> 
+		<strong>UCL Respondent</strong>: Michael Donnay<br/>
+		<strong>Uppsala Respondent</strong>: TBD
+	</div>
+</div>
+<p></p>
+<div class="card" id="Risam">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Thursday, 5 May 2022</h4>
+		<strong>Speaker</strong>: <a href="http://www.roopikarisam.com/about/">Prof. Roopika Risam </a>(Salem State)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 9:00 GMT (17:00 PST)<br/>
+    <strong>Registration</strong>: Interested participants may register <a href="https://stanford.zoom.us/webinar/register/WN_w8R3zm0SS66KpJ9WHHCQ-A">here</a><br/>
+		<strong>Chair</strong>: Giovanna Ceserani<br/> 
+		<strong>Uppsala Respondent</strong>: TBD<br/>
+		<strong>Stanford Respondent</strong>: Carmen Thong
+	</div>
+</div>
+<p></p>
+<div class="card" id="Williams">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Thursday, 19 May 2022</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Central Asia and the Role of Digital Heritage Inventories</h5>
+		<strong>Speaker</strong>: <a href="https://www.ucl.ac.uk/archaeology/people/tim-williams-professor-silk-roads-archaeology">Prof. Tim Williams </a>(UCL)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 9:00 PST (17:00 GMT)<br/>
+    <strong>Registration</strong>: Interested participants may register <a href="https://stanford.zoom.us/webinar/register/WN_Ko_LDqfrRKeigtE5S4Ci2w">here</a><br/>
+		<strong>Chair</strong>: Julianne Nyhan<br/> 
+		<strong>UCL Respondent</strong>: Anna Mladentseva<br/>
+		<strong>Uppsala Respondent</strong>: TBD
+	</div>
+</div>
+<p></p>
+
+<div class="card" id="Loyer">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Thursday, 2 June 2022</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Indigenous Knowledge in Digital Humanities</h5>
+		<strong>Speakers</strong>: <a href="https://library.mtroyal.ca/prf.php?account_id=31538">Jessie Loyer</a>(Mount Royal University)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 17:00 GMT (09:00 PST)<br/>
+    <strong>Registration</strong>: Interested participants may register <a href="https://stanford.zoom.us/webinar/register/WN_eXAu9r6XSu-nsFYlVNCYPw">here</a><br/>
+		<strong>Chair</strong>: Adam Crymble<br/> 
+		<strong>UCL Respondent</strong>: Jiayu Li<br/>
+		<strong>Stanford Respondent</strong>: TBD
+	</div>
+</div>
+
+
+
+<div class="card" id="milligan">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Wednesday, 27 Jan 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">From Engagement to Retreat? Historians and Digital Preservation 1968-2003</h5>
+		<strong>Speaker</strong>: <a href="https://uwaterloo.ca/history/people-profiles/ian-milligan">Ian Milligan </a>(University of Waterloo)<br/>
+		<strong>Venue</strong>: UCL DH, Online, via Zoom, 17:00 GMT (09:00 PST): <a href="/milligan.html">View the talk & read a recap</a><br/>
+		<strong>Chair</strong>: Adam Crymble<br/> 
+		<strong>UCL Respondent</strong>: Hannah Smyth<br/>
+		<strong>Stanford Respondent</strong>: Agnieszka Backman
+	</div>
+</div>
+<p></p>
+<div class="card" id="johnson">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Tuesday, 9 Feb 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Digital Humanities Against Enclosure</h5>
+		<strong>Speaker</strong>: <a href="https://history.jhu.edu/directory/jessica-johnson/">Jessica Johnson </a>(Johns Hopkins University)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 12:00 PST (20:00 GMT)<br/>
+		<strong>Chair</strong>: Giovanna Ceserani<br/> 
+		<strong>UCL Respondent</strong>: Nenna Orie Chuku<br/>
+		<strong>Stanford Respondent</strong>: Anna Toledano
+	</div>
+</div>
+<p></p>
+<div class="card" id="frank">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Tuesday, 23 Feb 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Digital Humanities and Spatial History: Atlantic World Stories</h5>
+		<p class="card-subtitle mb-2">The paper describes and discusses a series of DH projects that have developed at CESTA and have addressed major issues in the history of the Atlantic World, including slavery and the experience of enslaved and freed persons in particular.</p>
+		<strong>Speaker</strong>: <a href="https://history.stanford.edu/people/zephyr-frank">Zephyr Frank </a>(Stanford University)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 12:00 PST (20:00 GMT): <a href="/frank.html">View the talk & read a recap</a><br/>
+		<strong>Chair</strong>: Laura Stokes<br/> 
+		<strong>UCL Respondent</strong>: Madeline Tondi<br/>
+		<strong>Stanford Respondent</strong>: William Parish
+	</div>
+</div>
+<p></p>
+<div class="card" id="quiroga">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Wednesday, 10 Mar 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Multilingual Publishing in Digital Humanities</h5>
+		<strong>Speaker</strong>: <a href="https://rivaquiroga.cl/proyectos/">Riva Quiroga </a>(Programming Historian)<br/>
+		<strong>Venue</strong>: UCL DH, Online, via Zoom, 13:00 GMT (05:00 PST): <a href="/quiroga.html">View the talk & read a recap</a><br/>
+		<strong>Chair</strong>: Adam Crymble<br/> 
+		<strong>UCL Respondent</strong>: George Cooper<br/>
+		<strong>Stanford Respondent</strong>: Victoria Rahbar
+	</div>
+</div>
+<p></p>
+<div class="card" id="dombrowski">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Tuesday, 13 Apr 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Humanités numériques, цифровые гуманитарные науки, デジタル・ヒューマニティーズ: Histories and Futures of Linguistic Diversity in DH</h5>
+		<p class="card-subtitle mb-2">International, interdisciplinary spaces are inevitably sites of tension, where differences in linguistic and cultural norms run deeper than they initially appear. Establishing and maintaining a set of norms for a community to operate despite these differences requires ongoing dialogue within that community. This talk will reflect on language as one longstanding axis of diversity within digital humanities as it is carried out at the international level, as well as within different national contexts. This context will inform a frank discussion of the ways in which a general obliviousness towards languages commonly found in Anglophone countries has negatively impacted Anglophone scholars' research, pedagogy, and engagement with the broader field of DH. The talk will conclude with actionable steps that scholars, particularly in Anglophone countries, can take towards embracing language as an important axis of diversity.</p>
+		<strong>Speaker</strong>: <a href="https://dlcl.stanford.edu/people/quinn-dombrowski">Quinn Dombrowski </a>(Stanford University)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 12:00 PST (20:00 GMT): <a href="/dombrowski.html">View the talk & read a recap</a><br/>
+		<strong>Chair</strong>: Agnieszka Backman<br/> 
+		<strong>UCL Respondent</strong>: Jin Gao<br/>
+		<strong>Stanford Respondent</strong>: Maciej Kurzynski
+	</div>
+</div>
+<p></p>
+
+<div class="card" id="weingart">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Tuesday, 27 Apr 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">A Look Backwards Through the Index of Digital Humanities Conferences</h5>
+		<strong>Speakers</strong>: <a href="https://www.library.cmu.edu/about/people/scott-weingart">Scott Weingart </a>(Carnegie Mellon University), <a href="https://www.colorado.edu/libraries/nickoal-eichmann-kalwara">Nickoal Eichmann-Kalwara</a> (University of Colorado, Boulder)<br/>
+		<strong>Venue</strong>: UCL DH, Online, via Zoom, 17:00 GMT (09:00 PST): <a href="/weingart-eichmann-kalwara.html">Read a recap</a><br/>
+		<strong>Chair</strong>: Laura Stokes<br/> 
+		<strong>UCL Respondent</strong>: TBD<br/>
+		<strong>Stanford Respondent</strong>: Yunxin Li
+	</div>
+</div>
+<p></p>
+<div class="card" id="earhart">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Wednesday, 12 May 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Complicating the whiteness of Digital Humanities:  The Deep History of Black DH</h5>
+		<p class="card-subtitle mb-2">While projects focused on Black culture, texts and artifacts are not as rare as they once were there remains a lack of understanding of the rich and deep histories of Black DH and its impact on the field. Sharon Leon’s foundation chapter, “Complicating a ‘Great Man’ Narrative of Digital History in the United States,” serves as a model of the necessary documentation that scholars must compile of alternative histories of digital humanities. Accordingly, this talk will document a deep dig into the ecology of digital humanities, centering Black DH work in the field. Among the scholars’ work discussed will be Abduhl Alkalimat, creator of e-black studies, Bryan Carter, Virtual Harlem, Marilyn Miller Thomas-Houston, iBlack Studies and co-editor of the multi-media journal Fire!!, Ronald Bailey, who developed www.dignubia.org and www.nubianet.org and Afro Publishing without Walls, and Maryemma Graham, History of Black writing. An ongoing project, I am conducting interviews with such foundational Black dh scholars to better understand their contributions to the field.</p>
+		<strong>Speaker</strong>: <a href="https://liberalarts.tamu.edu/english/profile/amy-earhart/">Amy Earhart </a>(Texas A&M University)<br/>
+		<strong>Venue</strong>: UCL DH, Online, via Zoom, 17:00 GMT (09:00 PST): <a href="">Recording forthcoming</a><br/>
+		<strong>Chair</strong>: Julianne Nyhan<br/> 
+		<strong>UCL Respondent</strong>: Malithi Alahappruna<br/>
+		<strong>Stanford Respondent</strong>: Lakmali Jayasinghe
+	</div>
+</div>
+<p></p>
+<div class="card" id="schafer">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Wednesday, 26 May 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Web Archives Long View</h5>
+		<p class="card-subtitle mb-2">This research seminar aims to explicitly consider that research happens in context. This presentation proposes to address the topic of born-digital heritage and in particular of web archives in context. It aims to question the past, present and future paths of research based on the plethora of born-digital sources that developed from the mid-1990s. Analysis of web archives requires both taking into account the very shaping of these archives - e.g. web archiving in context - and placing research on these web archives in context, from the early studies of the 2000s which focused on the nature of web archives themselves and the methods for studying them to current research that takes them as sources for exploring digital cultures. Thus, the first two parts of our presentation, devoted respectively to the history of web archiving and of web archives in research, will explore the multiple contextual elements at work. These may be related to the Web itself and its evolution, to institutional policies, or to crawling and analysis tools, and understanding them is crucial for addressing the current and future challenges that will arise for researchers, whether they concern transnational approaches, ethical issues or a claim for enhanced contextualization. In conclusion we will broaden the question to digital humanities, and consider why web archive studies have remained relatively marginalised in digital humanities discourse.</p>
+		<strong>Speakers</strong>: <a href="https://www.c2dh.uni.lu/people/valerie-schafer">Valérie Schafer </a>(University of Luxembourg), <a href="https://research.sas.ac.uk/search/staff/126/professor-jane-winters/">Jane Winters</a> (School of Advanced Study, University of London)<br/>
+		<strong>Venue</strong>: UCL DH, Online, via Zoom, 17:00 GMT (09:00 PST): <a href="">Recap forthcoming</a><br/>
+		<strong>Chair</strong>: Giovanna Ceserani<br/> 
+		<strong>UCL Respondent</strong>: Opher Mansour<br/>
+		<strong>Stanford Respondent</strong>: Merve Tekgurler
+	</div>
+</div>
+<p></p>
+
+<div class="card" id="zaagsma">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Wednesday, 9 June 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Uncovering Digital History’s Forgotten Roots: the Work of the Association for History and Computing</h5>
+		<p class="card-subtitle mb-2">This talk has two parts. It will first attempt to frame what a history of digital history might look like, by focusing on hybridity as a key characteristic of historical research, seen as some form of integrating newly emerging tools, technologies, materials, and/or practices in historical research, and mapped and qualified according to the main phases of historical research. My main argument here is that, in order to ground our current ‘digital’ practices and learn from past experiences and expertise, we need an answer to the question: what were, and are, the continuities and ruptures in the use and uptake of new technologies in historical research, and in the debates that accompanied them?<br /><br />
+		The paper will then proceed to outline what groundwork is necessary to explore digital history’s forgotten roots: a basic overview of the field’s different spatio-temporal trajectories and the networks of computing historians in the pre-PC and early PC period. A key focal point for such a reconstruction are the DH conferences that took place in the 1960s and 1970s, either as singular events or strands of bigger conferences such as the International Congress of Historical Sciences in Moscow in 1970, and later those that were organised under the aegis of the Association for History and Computing (AHC, 1987-2001) and its national member organisations. By studying which scholars attended and where they came from, and by linking that to the topics and methods that were discussed, it will be possible to chart, over time, shifting geographical, topical and methodological developments.<br /><br />
+	In the second part of my paper, I will provide the first results of a concrete case study which is part of this broader endeavour, namely a web archaeology of the old AHC website and H-NET Discussion List for History and Computing (now: H-DigitalHistory).</p>
+		<strong>Speaker</strong>: <a href="https://www.c2dh.uni.lu/people/gerben-zaagsma">Gerben Zaagsma </a>(University of Luxembourg)<br/>
+		<strong>This talk has been canceled.</strong><br/>
+		<strong>Chair</strong>: Julianne Nyhan<br/> 
+		<strong>UCL Respondent</strong>: Marco Humbel<br/>
+		<strong>Stanford Respondent</strong>: TBD
+	</div>
+</div>
+<p></p>
+
+<div class="card" id="algee-hewitt">
+	<div class="card-body past-talk">
+		<h4 class="card-title">Tuesday, 22 June 2021</h4>
+		<h5 class="card-subtitle mb-2 text-muted">Laboratory Life in the Humanities: Computation, Criticism, and Collaboration</h5>
+		<p class="card-subtitle mb-2">The Digital Humanities have profoundly altered the way that humanities scholars work, research, and teach. While the introduction of computational methods, from GIS, to Digital Archives, to Text Mining, have opened up new fields to practitioners, these fields have also changed the social fabric of the humanities. Although the myth of the lone scholar, toiling away in their office, or in the archives, remains deeply embedded in the psyche of the discipline, the growing influence of the Digital Humanities has begun to offer scholars other opportunities for research work and teaching. Not only are our new methods collaborative by nature, they are often collaborative by necessity, frequently requiring us to work in teams that can leverage different experience and skills towards a set of research goals. In this talk, I want to explore the ramifications of this shift in research practice, focusing on the sociology of the humanities lab, as distinct from both the science laboratory, and the traditional practices of History, Classics, Philosophy, Cultural Studies, and Literary Study. How has the collaborative nature of our work altered the kinds of research that we can produce? How has interdisciplinary cooperation challenged ideas of evidence, method and results in the humanities? How has the collaborative model of research changed our pedagogy? What new kinds of equality, and inequality, between faculty, staff and students, has this change enabled? And what does it mean to work collaborative in fields whose institutional structures persist in disincentivizing collaboration? Drawing on my own experience working at, and directing, the Stanford Literary Lab, an ongoing collaborative research group that is celebrating its 10th anniversary this year, I want to focus on the outstanding questions that we are only now beginning to address around this radical shift in the humanities.</p>
+		<strong>Speaker</strong>: <a href="https://english.stanford.edu/people/mark-algee-hewitt">Mark Algee-Hewitt </a>(Stanford University)<br/>
+		<strong>Venue</strong>: CESTA, Online, via Zoom, 12:00 PST (20:00 GMT): <a href="https://mediacentral.ucl.ac.uk/Play/66892">View the talk</a><br/>
+		<strong>Chair</strong>: Agnieszka Backman<br/> 
+		<strong>UCL Respondent</strong>: Urszula Pawlicka-Deger (King’s College London)<br/>
+		<strong>Stanford Respondent</strong>: Mae Velloso-Lyons
+	</div>
+</div>
+<p></p>
+
+<button type="button" class="btn btn-light" onclick="window.location.href='#top';">Back to the top</button>
+
+
+---
+layout: longview_default
+title: Schedule
+---
+
+<h1 class="text-center my-5" id="top">Schedule</h1>
+
 <div class="card" id="milligan">
 	<div class="card-body past-talk">
 		<h4 class="card-title">Wednesday, 27 Jan 2021</h4>


### PR DESCRIPTION
Added speakers for 2022, incl. registration links. Need to add a boundary to separate 2022 events from those previously held.